### PR TITLE
Add ipynb.cn to iframe allowlist

### DIFF
--- a/claat/nodes/iframe.go
+++ b/claat/nodes/iframe.go
@@ -25,6 +25,7 @@ var IframeAllowlist = []string{
 	"angular.cn",
 	"codelabs.cn",
 	"google.cn",
+	"ipynb.cn",
 }
 
 // NewIframeNode creates a new embedded iframe.


### PR DESCRIPTION
## Summary
- allow embedding ipynb.cn by adding it to the iframe domain allowlist

## Testing
- `go test ./...` *(fails: no route to host)*